### PR TITLE
rockpi-4b-rk3399.coffee: Fix boot partition number

### DIFF
--- a/rockpi-4b-rk3399.coffee
+++ b/rockpi-4b-rk3399.coffee
@@ -27,8 +27,7 @@ module.exports =
 
 	configuration:
 		config:
-			partition:
-				primary: 1
+			partition: 4
 			path: '/config.json'
 
 	initialization: commonImg.initialization


### PR DESCRIPTION
The rockpi-4b-rk3399 uses a different partitioning scheme
so let's set here the correct boot partition number.

Changelog-entry: Fix boot partition number in rockpi-4b-rk3399.coffee
Signed-off-by: Florin Sarbu <florin@balena.io>