### PR TITLE
hostapp-update-hooks: Add missing u-boot hook

### DIFF
--- a/layers/meta-balena-rockpi/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bbappend
+++ b/layers/meta-balena-rockpi/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bbappend
@@ -2,4 +2,5 @@ FILESEXTRAPATHS_append := ":${THISDIR}/files"
 
 HOSTAPP_HOOKS += " \
     99-flash-bootloader \
+    99-resin-uboot \
 "


### PR DESCRIPTION
We need this hook for u-boot based boards

Changelog-entry: Add missing u-boot hostapp update hook
Signed-off-by: Florin Sarbu <florin@balena.io>