### PR TITLE
u-boot-rockpi: Fix file write failure when saving bootcount

### DIFF
--- a/layers/meta-balena-rockpi/recipes-bsp/u-boot/files/0002-fs-fat-fix-wrong-casting-to-unsigned-value-of-sect_t.patch
+++ b/layers/meta-balena-rockpi/recipes-bsp/u-boot/files/0002-fs-fat-fix-wrong-casting-to-unsigned-value-of-sect_t.patch
@@ -1,0 +1,38 @@
+From 6e2151c729674aecabf5ec5a96dac97433632009 Mon Sep 17 00:00:00 2001
+From: Seung-Woo Kim <sw0312.kim@samsung.com>
+Date: Mon, 4 Jun 2018 20:45:54 +0900
+Subject: [PATCH] fs: fat: fix wrong casting to unsigned value of
+ sect_to_cluster()
+
+After the commit 265edc03d5a1 ("fs/fat: Clean up open-coded sector
+<-> cluster conversions"), it is hung up writing new file to FAT16
+disk with more than 19 files in armv7. It is because result value
+of sect_to_cluster() is not proper by casting from signed value to
+unsigned value. Fix the wrong casting of sect_to_cluster().
+
+Reported-by: Jaehoon Chung <jh80.chung@samsung.com>
+Signed-off-by: Seung-Woo Kim <sw0312.kim@samsung.com>
+Reviewed-by: Lukasz Majewski <lukma@denx.de>
+
+Upstream-Status: Backport
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ include/fat.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/fat.h b/include/fat.h
+index 7dada411e5..09e1423685 100644
+--- a/include/fat.h
++++ b/include/fat.h
+@@ -180,7 +180,7 @@ static inline u32 clust_to_sect(fsdata *fsdata, u32 clust)
+ 	return fsdata->data_begin + clust * fsdata->clust_size;
+ }
+ 
+-static inline u32 sect_to_clust(fsdata *fsdata, u32 sect)
++static inline u32 sect_to_clust(fsdata *fsdata, int sect)
+ {
+ 	return (sect - fsdata->data_begin) / fsdata->clust_size;
+ }
+-- 
+2.17.1
+

--- a/layers/meta-balena-rockpi/recipes-bsp/u-boot/u-boot-rockpi-4.bbappend
+++ b/layers/meta-balena-rockpi/recipes-bsp/u-boot/u-boot-rockpi-4.bbappend
@@ -6,7 +6,10 @@ inherit resin-u-boot
 
 DEPENDS += "radxa-binary-loader radxa-binary-native"
 
-SRC_URI_append = " file://0001-Integrate-with-Balena-u-boot-environment.patch"
+SRC_URI_append = " \
+    file://0001-Integrate-with-Balena-u-boot-environment.patch \
+    file://0002-fs-fat-fix-wrong-casting-to-unsigned-value-of-sect_t.patch \
+"
 
 BALENA_BOOT_PART_rockpi-4b-rk3399 = "4"
 BALENA_DEFAULT_ROOT_PART_rockpi-4b-rk3399 = "5"


### PR DESCRIPTION
We backport an u-boot patch in order to fix the following:

writing bootcount.env
Error: Invalid FAT entry: 0x3ffffffa
Invalid FAT entry
Error: Invalid FAT entry: 0x3ffffffa
"Synchronous Abort" handler, esr 0x96000010
* Relocate offset = 00000000f5c07000
* ELR(PC)    =   0000000000262618
* LR         =   0000000000263b54
* SP         =   00000000f3df0a40

Changelog-entry: Backport u-boot fat fs related patch in order to fix write failure when saving bootcount
Signed-off-by: Florin Sarbu <florin@balena.io>