### PR TITLE
linux-rockpi-4b: load i2c7 bus by default

### DIFF
--- a/layers/meta-balena-rockpi/recipes-kernel/linux/linux-rockpi-4b_%.bbappend
+++ b/layers/meta-balena-rockpi/recipes-kernel/linux/linux-rockpi-4b_%.bbappend
@@ -5,5 +5,6 @@ inherit kernel-resin
 # on the rockpi-4b.
 do_deploy_append_rockpi-4b-rk3399() {
     sed -i 's/intfc:spi1=off/intfc:spi1=on/g' ${DEPLOYDIR}/hw_intfc.conf
+    sed -i 's/intfc:i2c7=off/intfc:i2c7=on/g' ${DEPLOYDIR}/hw_intfc.conf
     sed -i 's/#intfc:dtoverlay=devspi1/intfc:dtoverlay=devspi1/g' ${DEPLOYDIR}/hw_intfc.conf
 }


### PR DESCRIPTION
load i2c7 bus by default as this is the main i2c bus on the 40 pin head, physical pins 3 and 5

Closes: #26
Change-type: patch
Changelog-entry: Turn i2c7 bus on by default
Signed-off-by: Aaron Shaw <shawaj@gmail.com>