### PR TITLE
balena-image: ensure u-boot files are present when generating rootfs

### DIFF
--- a/layers/meta-balena-rockpi/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-rockpi/recipes-core/images/balena-image.inc
@@ -44,3 +44,6 @@ IMAGE_CMD_balenaos-img_append () {
     dd if=${DEPLOY_DIR_IMAGE}/u-boot.img of=${BALENA_RAW_IMG} conv=notrunc bs=512 seek=16384
     dd if=${DEPLOY_DIR_IMAGE}/trust.img of=${BALENA_RAW_IMG} conv=notrunc bs=512 seek=24576
 }
+
+# Ensure extlinux.conf files are deployed
+do_rootfs_balenaos-img[depends] += " u-boot-rockpi-4:do_deploy "


### PR DESCRIPTION
We spotted the following error in a meta-balena build PR, on the rockpi

    extlinux.conf_flasher is an invalid path referenced in BALENA_BOOT_PARTITION_FILES

Changelog-entry: balena-image: ensure u-boot files are present when generating rootfs
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Addresses error found in: https://github.com/balena-os/meta-balena/pull/2501 -> https://jenkins.product-os.io/job/yocto-rockpi-4b-rk3399/1472/console