### PR TITLE
brcmfmac.bb: Update brcmfmac to version that disables powersave

### DIFF
--- a/layers/meta-balena-rockpi/recipes-kernel/cypress-backports/brcmfmac.bb
+++ b/layers/meta-balena-rockpi/recipes-kernel/cypress-backports/brcmfmac.bb
@@ -12,7 +12,7 @@ DEPENDS += "bison-native flex-native"
 PR="r0"
 
 SRC_URI = "git://github.com/balena-os/cypress-backports.git;branch=v5.4.18-2021_0527;protocol=https"
-SRCREV = "377fc49500635649ab38d7f504b4c81b2d117cb1"
+SRCREV = "9caf48da1a252a256e0c8e9b66dd514aafad6056"
 
 S = "${WORKDIR}/git/v5.4.18-backports"
 


### PR DESCRIPTION
We disable wireless powersave in order to fix latency issues:
https://github.com/balena-os/balena-rockpi/issues/49

Changelog-entry: Ensure wireless powersave if off by default
Signed-off-by: Florin Sarbu <florin@balena.io>