### PR TITLE
workflows: Add build and deploy on release tag workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,0 +1,18 @@
+name: 'Deploy on release tag'
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+\+?r?e?v?[0-9]?
+      - v20[0-9][0-9].[0-1]?[1470].[0-9]+
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  release-on-tag:
+    uses: balena-os/github-workflows/.github/workflows/build_and_deploy.yml@v0.0.5
+    with:
+      deployTo: "production"
+      final: "no"
+    secrets: inherit


### PR DESCRIPTION
This workflow will launch a Jenkins build and draft deploy job when a new
tag is made.

Changelog-entry: Add build and deploy workflow
Signed-off-by: Alex Gonzalez <alexg@balena.io>
