### PR TITLE
u-boot-rockpi-4.bbappend: Revert the balena integration rework

### DIFF
--- a/layers/meta-balena-rockpi/recipes-bsp/u-boot/files/0001-Integrate-with-Balena-u-boot-environment_rockpi4b.patch
+++ b/layers/meta-balena-rockpi/recipes-bsp/u-boot/files/0001-Integrate-with-Balena-u-boot-environment_rockpi4b.patch
@@ -1,0 +1,40 @@
+From f10897ddbb91f05cbe2a87138ec8c050a9392da8 Mon Sep 17 00:00:00 2001
+From: Florin Sarbu <florin@balena.io>
+Date: Wed, 9 Mar 2022 10:07:50 +0100
+Subject: [PATCH] Integrate with Balena u-boot environment
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ configs/rock-pi-4b-rk3399_defconfig | 2 +-
+ include/configs/rockchip-common.h   | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/configs/rock-pi-4b-rk3399_defconfig b/configs/rock-pi-4b-rk3399_defconfig
+index 57f176c682..18e8fcff9d 100644
+--- a/configs/rock-pi-4b-rk3399_defconfig
++++ b/configs/rock-pi-4b-rk3399_defconfig
+@@ -50,7 +50,7 @@ CONFIG_CMD_MMC=y
+ CONFIG_CMD_PCI=y
+ CONFIG_CMD_USB=y
+ # CONFIG_CMD_ITEST is not set
+-# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_SETEXPR=y
+ CONFIG_CMD_CACHE=y
+ # CONFIG_CMD_MISC is not set
+ # CONFIG_ISO_PARTITION is not set
+diff --git a/include/configs/rockchip-common.h b/include/configs/rockchip-common.h
+index a8d4e52743..597be0a557 100644
+--- a/include/configs/rockchip-common.h
++++ b/include/configs/rockchip-common.h
+@@ -150,6 +150,7 @@
+ 	"fastboot usb 0;"
+ #else
+ #define RKIMG_BOOTCOMMAND \
++	"setenv resin_kernel_load_addr ${kernel_addr_r}; run resin_set_kernel_root; run set_os_cmdline;"\
+ 	"run distro_bootcmd;" \
+ 	"boot_android ${devtype} ${devnum};" \
+ 	"bootrkp;"
+-- 
+2.17.1
+

--- a/layers/meta-balena-rockpi/recipes-bsp/u-boot/u-boot-rockpi-4.bbappend
+++ b/layers/meta-balena-rockpi/recipes-bsp/u-boot/u-boot-rockpi-4.bbappend
@@ -7,9 +7,9 @@ inherit resin-u-boot
 DEPENDS += "radxa-binary-loader radxa-binary-native"
 
 SRC_URI_append = " \
+    file://0001-Integrate-with-Balena-u-boot-environment_rockpi4b.patch \
     file://0002-fs-fat-fix-wrong-casting-to-unsigned-value-of-sect_t.patch \
     file://0003-Revert-cmd-nvedit-add-0x-prefix-for-hex-value.patch \
-    file://balenaos_bootcommand.cfg \
 "
 
 BALENA_BOOT_PART_rockpi-4b-rk3399 = "4"


### PR DESCRIPTION
The original intent needs additional work to make it function
as needed so let's revert the rework for now and we'll revisit

Changelog-entry: Revert the u-boot balena integration rework for RockPi 4B because it needed additional work
Signed-off-by: Florin Sarbu <florin@balena.io>