### PR TITLE
linux-rockpi-4_%.bbappend: Revert device tree aliases

### DIFF
--- a/layers/meta-balena-rockpi/recipes-kernel/linux/files/0002-Revert-arm64-dts-rockchip-fix-ROCK-Pi-4-device-alias.patch
+++ b/layers/meta-balena-rockpi/recipes-kernel/linux/files/0002-Revert-arm64-dts-rockchip-fix-ROCK-Pi-4-device-alias.patch
@@ -1,0 +1,57 @@
+From b69c0edbf198d05f99687405d6a59eb6bc44eef6 Mon Sep 17 00:00:00 2001
+From: Florin Sarbu <florin@balena.io>
+Date: Fri, 3 Jun 2022 16:05:38 +0200
+Subject: [PATCH] Revert "arm64: dts: rockchip: fix ROCK Pi 4 device aliases"
+
+This reverts commit 86a614bc15b3b1aeb3a9a9e395aedd088c70e35e.
+
+Requested by customer here https://jel.ly.fish/73928db3-83ea-4720-b754-3f9bb38bfcb4
+because they want to have the older spidev32766.0 node name:
+https://github.com/radxa/kernel/blob/86a614bc15b3b1aeb3a9a9e395aedd088c70e35e/drivers/spi/spi.c#L1805-L1815
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ .../boot/dts/rockchip/rk3399-rock-pi-4.dtsi   | 26 -------------------
+ 1 file changed, 26 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+index a3e1a65b77eb..5ce69532b28b 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+@@ -51,32 +51,6 @@
+ 
+ / {
+ 
+-	aliases {
+-		dsi0 = &dsi;
+-		dsi1 = &dsi1;
+-		ethernet0 = &gmac;
+-		i2c0 = &i2c0;
+-		i2c1 = &i2c1;
+-		i2c2 = &i2c2;
+-		i2c3 = &i2c3;
+-		i2c4 = &i2c4;
+-		i2c5 = &i2c5;
+-		i2c6 = &i2c6;
+-		i2c7 = &i2c7;
+-		i2c8 = &i2c8;
+-		serial0 = &uart0;
+-		serial1 = &uart1;
+-		serial2 = &uart2;
+-		serial3 = &uart3;
+-		serial4 = &uart4;
+-		spi0 = &spi0;
+-		spi1 = &spi1;
+-		spi2 = &spi2;
+-		spi3 = &spi3;
+-		spi4 = &spi4;
+-		spi5 = &spi5;
+-	};
+-
+ 	fiq_debugger: fiq-debugger {
+ 		status = "disabled";
+ 		compatible = "rockchip,fiq-debugger";
+-- 
+2.17.1
+

--- a/layers/meta-balena-rockpi/recipes-kernel/linux/linux-rockpi-4_%.bbappend
+++ b/layers/meta-balena-rockpi/recipes-kernel/linux/linux-rockpi-4_%.bbappend
@@ -3,6 +3,8 @@ inherit kernel-resin
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI_append = " file://0001-arm64-armv8_deprecated-Warn-just-once-about-deprecat.patch"
 
+SRC_URI_append_rockpi-4b-rk3399 = " file://0002-Revert-arm64-dts-rockchip-fix-ROCK-Pi-4-device-alias.patch"
+
 # spidev module is enabled by default in meta-balena,
 # so let's enable the spidev overlay by default
 # on the rockpi-4b.


### PR DESCRIPTION
The customer requested here https://jel.ly.fish/73928db3-83ea-4720-b754-3f9bb38bfcb4
to bring back the older spidev32766.0 node name:
https://github.com/radxa/kernel/blob/86a614bc15b3b1aeb3a9a9e395aedd088c70e35e/drivers/spi/spi.c#L1805-L1815

Changelog-entry: Revert device tree aliases for bringing back dynamic spi bus name numbering
Signed-off-by: Florin Sarbu <florin@balena.io>